### PR TITLE
Stop CommandManager#DefaultExecutor from printing stacktrace.

### DIFF
--- a/bukkit/src/main/java/lc/vq/exhaust/bukkit/command/CommandManager.java
+++ b/bukkit/src/main/java/lc/vq/exhaust/bukkit/command/CommandManager.java
@@ -191,7 +191,6 @@ public class CommandManager extends AbstractCommandManager {
                     return true;
                 }
 
-                e.printStackTrace();
                 sender.sendMessage(ChatColor.RED + "An unexpected error occurred.");
             }
 


### PR DESCRIPTION
CommandException has always been used as a means of terminating the command with a message. (See WorldEdit's CommandManager)